### PR TITLE
refactor: make wacom library standalone

### DIFF
--- a/projects/wacom/src/lib/components/alert/alert.component.ts
+++ b/projects/wacom/src/lib/components/alert/alert.component.ts
@@ -1,10 +1,12 @@
 import { Component, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
 	selector: 'alert',
-	templateUrl: './alert.component.html',
-	styleUrls: ['./alert.component.scss'],
-	standalone: false,
+        templateUrl: './alert.component.html',
+        styleUrls: ['./alert.component.scss'],
+        standalone: true,
+        imports: [CommonModule],
 })
 export class AlertComponent {
 	@ViewChild('alert', { static: false }) alert: any;

--- a/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.ts
+++ b/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.ts
@@ -2,9 +2,10 @@ import { Component } from '@angular/core';
 
 @Component({
 	selector: 'lib-wrapper',
-	templateUrl: './wrapper.component.html',
-	styleUrls: ['./wrapper.component.scss'],
-	standalone: false,
+        templateUrl: './wrapper.component.html',
+        styleUrls: ['./wrapper.component.scss'],
+        standalone: true,
+        imports: [],
 })
 export class WrapperComponent {
 	constructor() {}

--- a/projects/wacom/src/lib/components/files/files.component.ts
+++ b/projects/wacom/src/lib/components/files/files.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
 	selector: 'lib-files',
-	templateUrl: './files.component.html',
-	styleUrls: ['./files.component.scss'],
-	standalone: false,
+        templateUrl: './files.component.html',
+        styleUrls: ['./files.component.scss'],
+        standalone: true,
+        imports: [CommonModule],
 })
 export class FilesComponent {
 	public fs: any;

--- a/projects/wacom/src/lib/components/loader/loader.component.ts
+++ b/projects/wacom/src/lib/components/loader/loader.component.ts
@@ -1,10 +1,12 @@
 import { Component, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
 	selector: 'lib-loader',
-	templateUrl: './loader.component.html',
-	styleUrls: ['./loader.component.scss'],
-	standalone: false,
+        templateUrl: './loader.component.html',
+        styleUrls: ['./loader.component.scss'],
+        standalone: true,
+        imports: [CommonModule],
 })
 export class LoaderComponent {
 	@ViewChild('loader', { static: false }) loader: any;

--- a/projects/wacom/src/lib/components/modal/modal.component.ts
+++ b/projects/wacom/src/lib/components/modal/modal.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
 	selector: 'lib-modal',
-	templateUrl: './modal.component.html',
-	styleUrls: ['./modal.component.scss'],
-	standalone: false,
+        templateUrl: './modal.component.html',
+        styleUrls: ['./modal.component.scss'],
+        standalone: true,
+        imports: [CommonModule],
 })
 export class ModalComponent implements OnInit {
 	class: string = '';

--- a/projects/wacom/src/lib/directives/click-outside.directive.ts
+++ b/projects/wacom/src/lib/directives/click-outside.directive.ts
@@ -7,8 +7,8 @@ import {
 } from '@angular/core';
 
 @Directive({
-	selector: '[clickOutside]',
-	standalone: false,
+        selector: '[clickOutside]',
+        standalone: true,
 })
 export class ClickOutsideDirective {
 	@Output() clickOutside: EventEmitter<Event> = new EventEmitter<Event>();

--- a/projects/wacom/src/lib/directives/popup/index.ts
+++ b/projects/wacom/src/lib/directives/popup/index.ts
@@ -1,4 +1,3 @@
 export * from './popup.component';
 export * from './popup.directive';
-export * from './popup.module';
 export * from './popup-options.interface';

--- a/projects/wacom/src/lib/directives/popup/popup.component.ts
+++ b/projects/wacom/src/lib/directives/popup/popup.component.ts
@@ -1,13 +1,14 @@
 import {
-	Component,
-	ElementRef,
-	HostListener,
-	HostBinding,
-	Input,
-	OnInit,
-	EventEmitter,
-	Renderer2,
+        Component,
+        ElementRef,
+        HostListener,
+        HostBinding,
+        Input,
+        OnInit,
+        EventEmitter,
+        Renderer2,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { CoreService } from '../../services/core.service';
 
 @Component({
@@ -16,8 +17,9 @@ import { CoreService } from '../../services/core.service';
 	host: {
 		class: 'popup',
 	},
-	styleUrls: ['./popup.component.sass'],
-	standalone: false,
+        styleUrls: ['./popup.component.sass'],
+        standalone: true,
+        imports: [CommonModule],
 })
 export class PopupComponent {
 	_show: boolean = false;

--- a/projects/wacom/src/lib/directives/popup/popup.directive.ts
+++ b/projects/wacom/src/lib/directives/popup/popup.directive.ts
@@ -29,9 +29,9 @@ export interface AdComponent {
 }
 
 @Directive({
-	selector: '[popup]',
-	exportAs: 'popup',
-	standalone: false,
+        selector: '[popup]',
+        exportAs: 'popup',
+        standalone: true,
 })
 export class PopupDirective {
 	hideTimeoutId: number;

--- a/projects/wacom/src/lib/guard/meta.guard.ts
+++ b/projects/wacom/src/lib/guard/meta.guard.ts
@@ -3,7 +3,7 @@ import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { MetaService } from '../services/meta.service';
 import { CONFIG_TOKEN, Config, DEFAULT_CONFIG } from '../interfaces/config';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class MetaGuard {
 	public static IDENTIFIER = 'MetaGuard';
 	private _meta: any;

--- a/projects/wacom/src/lib/pipes/arr.pipe.ts
+++ b/projects/wacom/src/lib/pipes/arr.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-	name: 'arr',
-	standalone: false,
+        name: 'arr',
+        standalone: true,
 })
 export class ArrPipe implements PipeTransform {
 	transform(data: any, type?: any, refresh?: any): any {

--- a/projects/wacom/src/lib/pipes/mongodate.pipe.ts
+++ b/projects/wacom/src/lib/pipes/mongodate.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-	name: 'mongodate',
-	standalone: false,
+        name: 'mongodate',
+        standalone: true,
 })
 export class MongodatePipe implements PipeTransform {
 	transform(_id: any) {

--- a/projects/wacom/src/lib/pipes/number.pipe.ts
+++ b/projects/wacom/src/lib/pipes/number.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
     name: 'number',
-    standalone: false
+    standalone: true
 })
 export class NumberPipe implements PipeTransform {
 	transform(value: unknown): number {

--- a/projects/wacom/src/lib/pipes/pagination.pipe.ts
+++ b/projects/wacom/src/lib/pipes/pagination.pipe.ts
@@ -1,9 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-	name: 'page',
-	pure: false,
-	standalone: false,
+        name: 'page',
+        pure: false,
+        standalone: true,
 })
 export class PaginationPipe implements PipeTransform {
 	transform(arr: any, config: any, sort: any, search = ''): any {

--- a/projects/wacom/src/lib/pipes/safe.pipe.ts
+++ b/projects/wacom/src/lib/pipes/safe.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 @Pipe({
-	name: 'safe',
-	standalone: false,
+        name: 'safe',
+        standalone: true,
 })
 export class SafePipe {
 	constructor(private sanitizer: DomSanitizer) {}

--- a/projects/wacom/src/lib/pipes/search.pipe.ts
+++ b/projects/wacom/src/lib/pipes/search.pipe.ts
@@ -5,8 +5,8 @@ import { Pipe, PipeTransform } from '@angular/core';
  *	Always returning an array, even if nothing is provided
  */
 @Pipe({
-	name: 'search',
-	standalone: false,
+        name: 'search',
+        standalone: true,
 })
 export class SearchPipe implements PipeTransform {
 	private c = 0;

--- a/projects/wacom/src/lib/pipes/splice.pipe.ts
+++ b/projects/wacom/src/lib/pipes/splice.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-	name: 'splice',
-	standalone: false,
+        name: 'splice',
+        standalone: true,
 })
 export class SplicePipe implements PipeTransform {
 	transform(from: any, which: any, refresh?: number): any {

--- a/projects/wacom/src/lib/pipes/split.pipe.ts
+++ b/projects/wacom/src/lib/pipes/split.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
     name: 'split',
-    standalone: false
+    standalone: true
 })
 export class SplitPipe implements PipeTransform {
 	transform(value: string, index = 0, devider = ':'): unknown {

--- a/projects/wacom/src/lib/wacom.module.ts
+++ b/projects/wacom/src/lib/wacom.module.ts
@@ -22,12 +22,12 @@ import { SearchPipe } from './pipes/search.pipe';
 import { MongodatePipe } from './pipes/mongodate.pipe';
 import { PaginationPipe } from './pipes/pagination.pipe';
 const PIPES = [
-	ArrPipe,
-	SafePipe,
-	SplicePipe,
-	SearchPipe,
-	MongodatePipe,
-	PaginationPipe,
+        ArrPipe,
+        SafePipe,
+        SplicePipe,
+        SearchPipe,
+        MongodatePipe,
+        PaginationPipe,
 ];
 
 /* components */
@@ -40,15 +40,19 @@ const LOCAL_COMPONENTS = [WrapperComponent, FilesComponent];
 const COMPONENTS = [LoaderComponent, ModalComponent, AlertComponent];
 
 @NgModule({
-	declarations: [...LOCAL_COMPONENTS, ...PIPES, ...COMPONENTS, ...DIRECTIVES],
-	exports: [...PIPES, ...COMPONENTS, ...DIRECTIVES],
-	imports: [CommonModule, FormsModule],
-	providers: [
-		{ provide: CONFIG_TOKEN, useValue: DEFAULT_CONFIG },
-		MetaGuard,
-		MetaService,
-		provideHttpClient(withInterceptorsFromDi()),
-	],
+        imports: [
+                CommonModule,
+                FormsModule,
+                ...LOCAL_COMPONENTS,
+                ...PIPES,
+                ...COMPONENTS,
+                ...DIRECTIVES,
+        ],
+        exports: [...PIPES, ...COMPONENTS, ...DIRECTIVES],
+        providers: [
+                { provide: CONFIG_TOKEN, useValue: DEFAULT_CONFIG },
+                provideHttpClient(withInterceptorsFromDi()),
+        ],
 })
 export class WacomModule {
 	static forRoot(


### PR DESCRIPTION
## Summary
- convert library components, directives and pipes to standalone with required imports
- provide meta guard globally
- rework WacomModule to import standalone artifacts

## Testing
- `npm test -- --watch=false` *(fails: Data path "/polyfills" must be array)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ff3b6608333830c8fc016ff8454