### PR TITLE
feat: support standalone configuration

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -12,6 +12,18 @@ Module which has common services and components which can be used on all project
 $ npm i --save wacom
 ```
 
+## Usage
+
+```typescript
+import { provideWacom } from 'wacom';
+
+export const appConfig = {
+	providers: [provideWacom()]
+};
+```
+
+`WacomModule` is still available for older applications but will be deprecated in future versions. Use `provideWacom` to configure the library when working with standalone APIs.
+
 ## Services
 
 | Name                                                               |                             Description                             |

--- a/projects/wacom/src/lib/provide-wacom.ts
+++ b/projects/wacom/src/lib/provide-wacom.ts
@@ -1,0 +1,12 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { CONFIG_TOKEN, Config, DEFAULT_CONFIG } from './interfaces/config';
+
+export function provideWacom(
+        config: Config = DEFAULT_CONFIG
+): EnvironmentProviders {
+        return makeEnvironmentProviders([
+                { provide: CONFIG_TOKEN, useValue: config },
+                provideHttpClient(withInterceptorsFromDi()),
+        ]);
+}

--- a/projects/wacom/src/lib/wacom.module.ts
+++ b/projects/wacom/src/lib/wacom.module.ts
@@ -52,6 +52,9 @@ const COMPONENTS = [LoaderComponent, ModalComponent, AlertComponent];
 		provideHttpClient(withInterceptorsFromDi()),
 	],
 })
+/**
+ * @deprecated Use provideWacom instead.
+ */
 export class WacomModule {
 	static forRoot(
 		config: Config = DEFAULT_CONFIG

--- a/projects/wacom/src/public-api.ts
+++ b/projects/wacom/src/public-api.ts
@@ -59,6 +59,7 @@ export * from './lib/services/ui.service';
  *	make different kind of modules, one which import all, other for piece by piece
  */
 export * from './lib/wacom.module';
+export * from './lib/provide-wacom';
 /*
  *	End of Support
  */


### PR DESCRIPTION
## Summary
- add `provideWacom` helper for configuring the library without NgModules
- mark `WacomModule` deprecated in favor of the provider and export it from public API
- document standalone usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e36cbf888833399c1ec9ec1b6cf7a