### PR TITLE
refactor: remove CoreService from StoreService

### DIFF
--- a/projects/wacom/src/lib/services/store.service.ts
+++ b/projects/wacom/src/lib/services/store.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { CONFIG_TOKEN, Config, DEFAULT_CONFIG } from '../interfaces/config';
-import { CoreService } from './core.service';
 
 @Injectable({
 	providedIn: 'root',
@@ -8,12 +7,11 @@ import { CoreService } from './core.service';
 export class StoreService {
 	private _prefix = '';
 
-	constructor(
-		@Inject(CONFIG_TOKEN) @Optional() private config: Config,
-		private core: CoreService
-	) {
-		this.config = this.config || DEFAULT_CONFIG;
-	}
+        constructor(
+                @Inject(CONFIG_TOKEN) @Optional() private config: Config
+        ) {
+                this.config = this.config || DEFAULT_CONFIG;
+        }
 
 	/**
 	 * Sets the prefix for storage keys.
@@ -270,7 +268,7 @@ export class StoreService {
 	 * @returns A promise that resolves to `true` if the value exists, otherwise `false`.
 	 *
 	 * @example
-	 * const store = new StoreService(config, core);
+         * const store = new StoreService(config);
 	 *
 	 * // Set a value and check if it exists
 	 * await store.setAsync('exampleKey', 'exampleValue');


### PR DESCRIPTION
## Summary
- drop unused CoreService dependency from StoreService
- clean up example usage in StoreService docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e39fb3c70833398725b681ec5f6ab