### PR TITLE
fix: refine store service null handling

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -905,7 +905,7 @@ Gets a value from storage.
 storeService.get('key', value => console.log(value), () => console.log('Error'));
 ```
 
-#### `getAsync(key: string): Promise<string>`
+#### `getAsync(key: string): Promise<string | null>`
 
 Gets a value from storage asynchronously.
 
@@ -915,7 +915,7 @@ Gets a value from storage asynchronously.
 
 **Returns**:
 
--   `Promise<string>`: A promise that resolves to the retrieved value.
+-   `Promise<string | null>`: A promise that resolves to the retrieved value or `null` if the key is missing.
 
 **Example**:
 

--- a/projects/wacom/src/lib/services/store.service.ts
+++ b/projects/wacom/src/lib/services/store.service.ts
@@ -97,26 +97,27 @@ export class StoreService {
 		}
 	}
 
-	/**
-	 * Gets a value from storage asynchronously.
-	 *
-	 * @param key - The storage key.
-	 * @returns A promise that resolves to the retrieved value.
-	 */
-	async getAsync(key: string): Promise<string> {
-		key = this.applyPrefix(key);
+        /**
+         * Gets a value from storage asynchronously.
+         *
+         * @param key - The storage key.
+         * @returns A promise that resolves to the retrieved value or `null` if the key is missing.
+         */
+        async getAsync(key: string): Promise<string | null> {
+                key = this.applyPrefix(key);
 
-		try {
-			if (this.config.store?.get) {
-				return await this.config.store.get(key);
-			} else {
-				return localStorage.getItem(key) || '';
-			}
-		} catch (err) {
-			console.error(err);
-			return '';
-		}
-	}
+                try {
+                        if (this.config.store?.get) {
+                                const value = await this.config.store.get(key);
+                                return value ?? null;
+                        } else {
+                                return localStorage.getItem(key);
+                        }
+                } catch (err) {
+                        console.error(err);
+                        return null;
+                }
+        }
 
 	/**
 	 * Sets a JSON value in storage.
@@ -178,15 +179,18 @@ export class StoreService {
 	 * @param key - The storage key.
 	 * @returns A promise that resolves to the retrieved value.
 	 */
-	async getJsonAsync<T = any>(key: string): Promise<T | null> {
-		const value = await this.getAsync(key);
-		try {
-			return JSON.parse(value);
-		} catch (err) {
-			console.error(err);
-			return null;
-		}
-	}
+        async getJsonAsync<T = any>(key: string): Promise<T | null> {
+                const value = await this.getAsync(key);
+                if (value === null) {
+                        return null;
+                }
+                try {
+                        return JSON.parse(value);
+                } catch (err) {
+                        console.error(err);
+                        return null;
+                }
+        }
 
 	/**
 	 * Removes a value from storage.
@@ -260,28 +264,28 @@ export class StoreService {
 		return key;
 	}
 
-	/**
-	 * Checks if a value exists in storage.
-	 *
-	 * This function checks whether a value is present for the given key in the storage.
-	 * It uses the configured storage mechanism if available; otherwise, it defaults to using `localStorage`.
-	 *
-	 * @param key - The storage key to check.
-	 * @returns A promise that resolves to `true` if the value exists, otherwise `false`.
-	 *
-	 * @example
-	 * const store = new StoreService(config, core);
-	 *
-	 * // Set a value and check if it exists
-	 * await store.setAsync('exampleKey', 'exampleValue');
-	 * const exists = await store.has('exampleKey');
-	 * console.log(exists); // Output: true
-	 *
-	 * @notes
-	 * - This method internally uses `getAsync` to retrieve the value and checks if it is not null or empty.
-	 * - An empty string value will still return `true` as the key exists in storage.
-	 */
-	async has(key: string): Promise<boolean> {
-		return !!(await this.getAsync(key));
-	}
+        /**
+         * Checks if a value exists in storage.
+         *
+         * This function checks whether a value is present for the given key in the storage.
+         * It uses the configured storage mechanism if available; otherwise, it defaults to using `localStorage`.
+         *
+         * @param key - The storage key to check.
+         * @returns A promise that resolves to `true` if the value exists, otherwise `false`.
+         *
+         * @example
+         * const store = new StoreService(config, core);
+         *
+         * // Set a value and check if it exists
+         * await store.setAsync('exampleKey', 'exampleValue');
+         * const exists = await store.has('exampleKey');
+         * console.log(exists); // Output: true
+         *
+         * @notes
+         * - This method internally uses `getAsync` and checks only for `null`.
+         * - An empty string value will still return `true` as the key exists in storage.
+         */
+        async has(key: string): Promise<boolean> {
+                return (await this.getAsync(key)) !== null;
+        }
 }


### PR DESCRIPTION
## Summary
- return `null` for missing keys in `getAsync`
- make `has` check explicitly for `null`
- document `getAsync`'s nullable return and clarify `has` notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e39f266608333ba3c12e1aa3da934