### PR TITLE
feat: add twitter meta title support

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -1194,7 +1194,7 @@ metaService.setDefaults({ title: 'Default Title', description: 'Default Descript
 
 #### `setTitle(title?: string, titleSuffix?: string): MetaService`
 
-Sets the title and optional title suffix.
+Sets the title and optional title suffix, updating the `title`, `og:title`, and `twitter:title` meta tags.
 
 **Parameters**:
 

--- a/projects/wacom/src/lib/services/meta.service.spec.ts
+++ b/projects/wacom/src/lib/services/meta.service.spec.ts
@@ -1,0 +1,22 @@
+import { MetaService } from './meta.service';
+import { Meta, Title } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+
+describe('MetaService', () => {
+  let service: MetaService;
+  let meta: jasmine.SpyObj<Meta>;
+  let title: jasmine.SpyObj<Title>;
+  let router: Partial<Router>;
+
+  beforeEach(() => {
+    meta = jasmine.createSpyObj('Meta', ['updateTag', 'removeTag']);
+    title = jasmine.createSpyObj('Title', ['setTitle']);
+    router = { config: [] };
+    service = new MetaService(router as Router, meta, title, undefined);
+  });
+
+  it('should update twitter:title when setting title', () => {
+    service.setTitle('Test Title');
+    expect(meta.updateTag).toHaveBeenCalledWith({ property: 'twitter:title', content: 'Test Title' });
+  });
+});

--- a/projects/wacom/src/lib/services/meta.service.ts
+++ b/projects/wacom/src/lib/services/meta.service.ts
@@ -50,12 +50,13 @@ export class MetaService {
 			titleContent += isDefined(titleSuffix)
 				? titleSuffix
 				: this._meta.defaults['titleSuffix'] || '';
-		}
-		this._updateMetaTag('title', titleContent);
-		this._updateMetaTag('og:title', titleContent);
-		this.titleService.setTitle(titleContent);
-		return this;
-	}
+                }
+                this._updateMetaTag('title', titleContent);
+                this._updateMetaTag('og:title', titleContent);
+                this._updateMetaTag('twitter:title', titleContent);
+                this.titleService.setTitle(titleContent);
+                return this;
+        }
 
 	/**
 	 * Sets link tags.


### PR DESCRIPTION
## Summary
- update MetaService to populate `twitter:title`
- document `setTitle` meta tag behavior
- add unit test for twitter title update

## Testing
- `npx ng test wacom --watch=false` *(fails: Cannot find module 'karma')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e420da5308333ade3b11d0d049412