### PR TITLE
feat(meta): warn on missing MetaGuard in nested routes

### DIFF
--- a/projects/wacom/src/lib/services/meta.service.spec.ts
+++ b/projects/wacom/src/lib/services/meta.service.spec.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { MetaService } from './meta.service';
+import { Config } from '../interfaces/config.interface';
+
+function createService(routes: any[]): void {
+  const router: any = { config: routes };
+  const meta: any = { updateTag() {}, removeTag() {} };
+  const title: any = { setTitle() {} };
+  const config: Config = { meta: { warnMissingGuard: true, defaults: {} } };
+  new MetaService(router, meta, title, config);
+}
+
+test('warns when top-level route lacks MetaGuard', () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: any[]) => { warnings.push(args.join(' ')); };
+
+  createService([{ path: 'top', data: { meta: { description: 'd' } } }]);
+
+  console.warn = originalWarn;
+  assert.ok(warnings.some(w => w.includes('Route with path "top"')), 'should warn for top-level route');
+  assert.ok(warnings.some(w => w.includes('To disable these warnings')), 'should show disable message');
+});
+
+test('warns when nested child route lacks MetaGuard', () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: any[]) => { warnings.push(args.join(' ')); };
+
+  createService([{ path: 'parent', children: [{ path: 'child', data: { meta: { description: 'd' } } }] }]);
+
+  console.warn = originalWarn;
+  assert.ok(warnings.some(w => w.includes('Route with path "child"')), 'should warn for child route');
+  assert.ok(warnings.some(w => w.includes('To disable these warnings')), 'should show disable message');
+});

--- a/projects/wacom/src/lib/services/meta.service.ts
+++ b/projects/wacom/src/lib/services/meta.service.ts
@@ -142,26 +142,28 @@ export class MetaService {
 		const hasDefaultMeta = !!Object.keys(this._meta.defaults).length;
 		const hasMetaGuardInArr = (it: any) =>
 			it && it.IDENTIFIER === 'MetaGuard';
-		let hasShownWarnings = false;
-		this.router.config.forEach((route: Route) => {
-			const hasRouteMeta = route.data && route.data['meta'];
-			const showWarning =
-				!isDefined(route.redirectTo) &&
-				(hasDefaultMeta || hasRouteMeta) &&
-				!(route.canActivate || []).some(hasMetaGuardInArr);
-			if (showWarning) {
-				console.warn(
-					`Route with path "${route.path}" has ${
-						hasRouteMeta ? '' : 'default '
-					}meta tags, but does not use MetaGuard. Please add MetaGuard to the canActivate array in your route configuration`
-				);
-				hasShownWarnings = true;
-			}
-		});
-		if (hasShownWarnings) {
-			console.warn(
-				`To disable these warnings, set metaConfig.warnMissingGuard: false in your MetaConfig passed to MetaModule.forRoot()`
-			);
-		}
+                let hasShownWarnings = false;
+                const checkRoute = (route: Route) => {
+                        const hasRouteMeta = route.data && route.data['meta'];
+                        const showWarning =
+                                !isDefined(route.redirectTo) &&
+                                (hasDefaultMeta || hasRouteMeta) &&
+                                !(route.canActivate || []).some(hasMetaGuardInArr);
+                        if (showWarning) {
+                                console.warn(
+                                        `Route with path "${route.path}" has ${
+                                                hasRouteMeta ? '' : 'default '
+                                        }meta tags, but does not use MetaGuard. Please add MetaGuard to the canActivate array in your route configuration`
+                                );
+                                hasShownWarnings = true;
+                        }
+                        (route.children || []).forEach(checkRoute);
+                };
+                this.router.config.forEach(checkRoute);
+                if (hasShownWarnings) {
+                        console.warn(
+                                `To disable these warnings, set metaConfig.warnMissingGuard: false in your MetaConfig passed to MetaModule.forRoot()`
+                        );
+                }
 	}
 }


### PR DESCRIPTION
## Summary
- warn about missing MetaGuard recursively through child routes
- add unit tests covering top-level and nested route warnings

## Testing
- `npx tsc projects/wacom/src/lib/services/meta.service.ts projects/wacom/src/lib/interfaces/config.interface.ts projects/wacom/src/lib/services/meta.service.spec.ts --outDir tmp/test-compile --module commonjs --target es2018 --experimentalDecorators`
- `node --test tmp/test-compile/services/meta.service.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_689e4202b6ec8333bf3ab0543d3a5505