### PR TITLE
refactor: simplify reserved tag error message

### DIFF
--- a/projects/wacom/src/lib/services/meta.service.ts
+++ b/projects/wacom/src/lib/services/meta.service.ts
@@ -82,11 +82,11 @@ export class MetaService {
 	 * @returns The MetaService instance.
 	 */
 	setTag(tag: string, value: string, prop?: string): MetaService {
-		if (tag === 'title' || tag === 'titleSuffix') {
-			throw new Error(
-				`Attempt to set ${tag} through 'setTag': 'title' and 'titleSuffix' are reserved tag names. Please use 'MetaService.setTitle' instead`
-			);
-		}
+                if (tag === 'title' || tag === 'titleSuffix') {
+                        throw new Error(
+                                `Attempt to set ${tag} through 'setTag': 'title' and 'titleSuffix' are reserved. Use 'MetaService.setTitle' instead.`
+                        );
+                }
 		const content = isDefined(value)
 			? value
 			: this._meta.defaults[tag] || '';


### PR DESCRIPTION
## Summary
- streamline `setTag` error for reserved tags into a concise one-line string

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e41f1602c83338d7908f13f320870