### PR TITLE
feat(meta): merge defaults instead of replace

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -1180,7 +1180,7 @@ The `MetaService` manages meta tags and titles in an Angular application. It all
 
 #### `setDefaults(defaults: { [key: string]: string }): void`
 
-Sets the default meta tags.
+Sets the default meta tags, merging the provided values with any existing defaults.
 
 **Parameters**:
 
@@ -1190,6 +1190,8 @@ Sets the default meta tags.
 
 ```Typescript
 metaService.setDefaults({ title: 'Default Title', description: 'Default Description' });
+// Later calls merge with previous defaults instead of replacing them
+metaService.setDefaults({ description: 'Updated Description' });
 ```
 
 #### `setTitle(title?: string, titleSuffix?: string): MetaService`

--- a/projects/wacom/src/lib/services/meta.service.spec.ts
+++ b/projects/wacom/src/lib/services/meta.service.spec.ts
@@ -34,3 +34,21 @@ test('warns when nested child route lacks MetaGuard', () => {
   assert.ok(warnings.some(w => w.includes('Route with path "child"')), 'should warn for child route');
   assert.ok(warnings.some(w => w.includes('To disable these warnings')), 'should show disable message');
 });
+
+test('setDefaults merges new defaults with existing ones', () => {
+  const router: any = { config: [] };
+  const meta: any = { updateTag() {}, removeTag() {} };
+  const title: any = { setTitle() {} };
+  const config: Config = {
+    meta: { warnMissingGuard: false, defaults: { title: 'Old', description: 'Old' } },
+  };
+  const service = new MetaService(router, meta, title, config);
+
+  service.setDefaults({ description: 'New', extra: 'value' });
+
+  assert.deepStrictEqual((service as any)._meta.defaults, {
+    title: 'Old',
+    description: 'New',
+    extra: 'value',
+  });
+});

--- a/projects/wacom/src/lib/services/meta.service.ts
+++ b/projects/wacom/src/lib/services/meta.service.ts
@@ -26,14 +26,17 @@ export class MetaService {
 		this._warnMissingGuard();
 	}
 
-	/**
-	 * Sets the default meta tags.
-	 *
-	 * @param defaults - The default meta tags.
-	 */
-	setDefaults(defaults: { [key: string]: string }): void {
-		this._meta.defaults = defaults;
-	}
+        /**
+         * Sets the default meta tags.
+         *
+         * @param defaults - The default meta tags.
+         */
+        setDefaults(defaults: { [key: string]: string }): void {
+                this._meta.defaults = {
+                        ...this._meta.defaults,
+                        ...defaults,
+                };
+        }
 
 	/**
 	 * Sets the title and optional title suffix.


### PR DESCRIPTION
## Summary
- merge new default meta values with existing ones instead of replacing them
- document merging behavior of `setDefaults`
- add test covering merged defaults

## Testing
- `node --test projects/wacom/src/lib/services/meta.service.spec.ts` *(fails: Unknown file extension ".ts" for spec file)*

------
https://chatgpt.com/codex/tasks/task_e_689e46eac95c8333b0632f5c5c39206d