### PR TITLE
feat: support default meta links

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -1178,13 +1178,13 @@ The `MetaService` manages meta tags and titles in an Angular application. It all
 
 ### Methods
 
-#### `setDefaults(defaults: { [key: string]: string }): void`
+#### `setDefaults(defaults: MetaDefaults): void`
 
 Sets the default meta tags.
 
 **Parameters**:
 
--   `defaults` (object): The default meta tags.
+-   `defaults` (object): The default meta tags including optional `links`.
 
 **Example**:
 

--- a/projects/wacom/src/lib/guard/meta.guard.ts
+++ b/projects/wacom/src/lib/guard/meta.guard.ts
@@ -32,16 +32,15 @@ export class MetaGuard {
 		if (meta.title) {
 			this.metaService.setTitle(meta.title, meta.titleSuffix);
 		}
-		if (Array.isArray(meta.links)) {
-			this.metaService.setLink(meta.links);
-		} else if (typeof meta.links === 'string') {
-			this.metaService.setLink(meta.links.split(' '));
-		}
-		if (Array.isArray(this._meta.defaults?.links)) {
-			this.metaService.setLink(this._meta.defaults?.links);
-		} else if (typeof this._meta.defaults?.links === 'string') {
-			this.metaService.setLink(this._meta.defaults?.links.split(' '));
-		}
+                if (meta.links && Object.keys(meta.links).length) {
+                        this.metaService.setLink(meta.links);
+                }
+                if (
+                        this._meta.defaults?.links &&
+                        Object.keys(this._meta.defaults.links).length
+                ) {
+                        this.metaService.setLink(this._meta.defaults.links);
+                }
 		Object.keys(meta).forEach((prop) => {
 			if (
 				prop === 'title' ||
@@ -63,7 +62,10 @@ export class MetaGuard {
 			) {
 				return;
 			}
-			this.metaService.setTag(key, this._meta.defaults[key]);
-		});
-	}
+                        this.metaService.setTag(
+                                key,
+                                this._meta.defaults[key] as string
+                        );
+                });
+        }
 }

--- a/projects/wacom/src/lib/interfaces/config.interface.ts
+++ b/projects/wacom/src/lib/interfaces/config.interface.ts
@@ -1,14 +1,18 @@
 import { InjectionToken } from '@angular/core';
 
+export interface MetaDefaults {
+        title?: string;
+        titleSuffix?: string;
+        links?: Record<string, string>;
+        [key: string]: string | Record<string, string> | undefined;
+}
+
 export interface Config {
-	meta?: {
-		useTitleSuffix?: boolean;
-		warnMissingGuard?: boolean;
-		defaults?: {
-			title?: string;
-			titleSuffix?: string;
-		} & { [key: string]: string | undefined };
-	};
+        meta?: {
+                useTitleSuffix?: boolean;
+                warnMissingGuard?: boolean;
+                defaults?: MetaDefaults;
+        };
 	alert?: {
 		text?: string;
 		type?: string;
@@ -59,15 +63,15 @@ export interface Config {
 }
 export const CONFIG_TOKEN = new InjectionToken<Config>('config');
 export const DEFAULT_CONFIG: Config = {
-	meta: {
-		useTitleSuffix: false,
-		warnMissingGuard: true,
-		defaults: {},
-	},
-	socket: false,
-	http: {
-		url: '',
-		headers: {},
+        meta: {
+                useTitleSuffix: false,
+                warnMissingGuard: true,
+                defaults: { links: {} },
+        },
+        socket: false,
+        http: {
+                url: '',
+                headers: {},
 	},
 	store: {
 		prefix: '',

--- a/projects/wacom/src/lib/services/meta.service.ts
+++ b/projects/wacom/src/lib/services/meta.service.ts
@@ -2,9 +2,10 @@ import { Inject, Injectable, Optional } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { Route, Router } from '@angular/router';
 import {
-	CONFIG_TOKEN,
-	Config,
-	DEFAULT_CONFIG,
+        CONFIG_TOKEN,
+        Config,
+        DEFAULT_CONFIG,
+        MetaDefaults,
 } from '../interfaces/config.interface';
 
 const isDefined = (val: any) => typeof val !== 'undefined';
@@ -31,9 +32,9 @@ export class MetaService {
 	 *
 	 * @param defaults - The default meta tags.
 	 */
-	setDefaults(defaults: { [key: string]: string }): void {
-		this._meta.defaults = defaults;
-	}
+        setDefaults(defaults: MetaDefaults): void {
+                this._meta.defaults = defaults;
+        }
 
 	/**
 	 * Sets the title and optional title suffix.


### PR DESCRIPTION
## Summary
- allow configuring default meta links via `MetaDefaults`
- initialize `links` in the default config and document usage
- update meta guard and service to work with link definitions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e46d1f86083338b560e1ad9dab5c0