### PR TITLE
fix(meta-guard): add safe defaults

### DIFF
--- a/projects/wacom/src/lib/guard/meta.guard.ts
+++ b/projects/wacom/src/lib/guard/meta.guard.ts
@@ -9,15 +9,16 @@ import { MetaService } from '../services/meta.service';
 
 @Injectable({ providedIn: 'root' })
 export class MetaGuard {
-	public static IDENTIFIER = 'MetaGuard';
-	private _meta: any;
-	public constructor(
-		private metaService: MetaService,
-		@Inject(CONFIG_TOKEN) @Optional() private config: Config
-	) {
-		this._meta = config.meta;
-		if (!this.config) this.config = DEFAULT_CONFIG;
-	}
+        public static IDENTIFIER = 'MetaGuard';
+        private _meta: any;
+        public constructor(
+                private metaService: MetaService,
+                @Inject(CONFIG_TOKEN) @Optional() private config: Config
+        ) {
+                if (!this.config) this.config = DEFAULT_CONFIG;
+                this._meta = this.config.meta || {};
+                this._meta.defaults = this._meta.defaults || {};
+        }
 	public canActivate(
 		route: ActivatedRouteSnapshot,
 		state: RouterStateSnapshot


### PR DESCRIPTION
## Summary
- default meta configuration before using it
- fall back to empty objects for meta and defaults to avoid runtime errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e46adf8d08333b2f6d14b93263d71