### PR TITLE
feat: add firebase service

### DIFF
--- a/projects/wacom/src/lib/interfaces/config.interface.ts
+++ b/projects/wacom/src/lib/interfaces/config.interface.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { Meta } from './meta.interface';
+import { FirebaseConfig } from './firebase.interface';
 
 export interface Config {
 	meta?: Meta;
@@ -15,7 +16,7 @@ export interface Config {
 		close?: any;
 		buttons?: any;
 	};
-	modal?: {
+        modal?: {
 		size?: any;
 		timeout?: any;
 		timestart?: any;
@@ -23,10 +24,12 @@ export interface Config {
 		position?: string;
 		closable?: boolean;
 		unique?: string;
-	};
-	socket?: any;
-	io?: any;
-	http?: {
+        };
+        socket?: any;
+        io?: any;
+        firebase?: FirebaseConfig | boolean;
+        fb?: any;
+        http?: {
 		headers?: any;
 		url?: string;
 	};
@@ -57,9 +60,10 @@ export const DEFAULT_CONFIG: Config = {
 		useTitleSuffix: false,
 		warnMissingGuard: true,
 		defaults: { links: {} },
-	},
-	socket: false,
-	http: {
+        },
+        socket: false,
+        firebase: false,
+        http: {
 		url: '',
 		headers: {},
 	},

--- a/projects/wacom/src/lib/interfaces/firebase.interface.ts
+++ b/projects/wacom/src/lib/interfaces/firebase.interface.ts
@@ -1,0 +1,11 @@
+export interface FirebaseConfig {
+        /**
+         * Firebase app configuration passed to `initializeApp`.
+         */
+        options?: any;
+
+        /**
+         * Optional name for the Firebase app instance.
+         */
+        appName?: string;
+}

--- a/projects/wacom/src/lib/services/firebase.service.md
+++ b/projects/wacom/src/lib/services/firebase.service.md
@@ -1,0 +1,41 @@
+# FirebaseService
+
+Service for connecting to Firebase and performing basic CRUD operations.
+
+## Usage
+
+```typescript
+import { FirebaseService } from 'wacom';
+
+constructor(private firebase: FirebaseService) {
+        this.firebase.setConfig({
+                options: { /* firebase config */ }
+        });
+}
+
+async saveUser() {
+        await this.firebase.create('users', { name: 'John' });
+}
+```
+
+## Functions
+
+### setConfig(config)
+
+Configure and connect the Firebase app.
+
+### create(path, data)
+
+Add a document to a collection.
+
+### read(path, id?)
+
+Read all documents from a collection or a single document by ID.
+
+### update(path, id, data)
+
+Update a document.
+
+### delete(path, id)
+
+Remove a document from a collection.

--- a/projects/wacom/src/lib/services/firebase.service.ts
+++ b/projects/wacom/src/lib/services/firebase.service.ts
@@ -1,0 +1,152 @@
+import { Inject, Injectable, Optional } from '@angular/core';
+import {
+        CONFIG_TOKEN,
+        Config,
+        DEFAULT_CONFIG,
+} from '../interfaces/config.interface';
+import { FirebaseConfig } from '../interfaces/firebase.interface';
+import { CoreService } from './core.service';
+
+/**
+ * Service that wraps basic Firebase initialization and Firestore CRUD helpers.
+ *
+ * The Firebase library is expected to be provided via the global configuration
+ * under the `fb` property. Connection options can be supplied through the
+ * `firebase` configuration or by calling {@link setConfig}.
+ */
+@Injectable({
+        providedIn: 'root',
+})
+export class FirebaseService {
+        private _fbConfig: FirebaseConfig | boolean = false;
+
+        private _app: any;
+
+        private _db: any;
+
+        private _connected = false;
+
+        constructor(
+                @Inject(CONFIG_TOKEN) @Optional() private _config: Config,
+                private _core: CoreService
+        ) {
+                if (!this._config) {
+                        this._config = DEFAULT_CONFIG;
+                }
+
+                if (this._config.firebase) {
+                        this._fbConfig = this._config.firebase;
+                        this.load();
+                }
+        }
+
+        /**
+         * Set Firebase configuration and (re)initialize connection.
+         *
+         * @param config Firebase application configuration.
+         */
+        setConfig(config: FirebaseConfig): void {
+                this._fbConfig = config;
+
+                if (!this._config.firebase) {
+                        this._config.firebase = config;
+                }
+
+                this.load();
+        }
+
+        /**
+         * Initialize Firebase app and Firestore instance.
+         */
+        private load(): void {
+                if (!this._config.fb || !this._fbConfig) {
+                        return;
+                }
+
+                const fb = this._config.fb.default
+                        ? this._config.fb.default
+                        : this._config.fb;
+
+                const opts = typeof this._fbConfig === 'object' ? this._fbConfig.options : undefined;
+                const name =
+                        typeof this._fbConfig === 'object' && this._fbConfig.appName
+                                ? this._fbConfig.appName
+                                : undefined;
+
+                this._app = fb.initializeApp(opts || {}, name);
+
+                this._db = fb.firestore ? fb.firestore(this._app) : null;
+
+                this._connected = true;
+
+                this._core.complete('firebase');
+        }
+
+        private async _waitConnection(): Promise<void> {
+                if (this._connected || !this._config.firebase) {
+                        return;
+                }
+
+                await new Promise<void>((resolve) => {
+                        const check = () => {
+                                if (this._connected) {
+                                        resolve();
+                                } else {
+                                        setTimeout(check, 100);
+                                }
+                        };
+                        check();
+                });
+        }
+
+        /**
+         * Create a document in the specified collection.
+         *
+         * @param path Collection path.
+         * @param data Document data.
+         */
+        async create(path: string, data: any): Promise<any> {
+                await this._waitConnection();
+                return this._db.collection(path).add(data);
+        }
+
+        /**
+         * Read documents from the specified collection or document.
+         *
+         * @param path Collection path.
+         * @param id Optional document id. If provided, a single document is
+         *          returned, otherwise all documents are fetched.
+         */
+        async read(path: string, id?: string): Promise<any> {
+                await this._waitConnection();
+
+                if (id) {
+                        return this._db.collection(path).doc(id).get();
+                }
+
+                return this._db.collection(path).get();
+        }
+
+        /**
+         * Update a document in the specified collection.
+         *
+         * @param path Collection path.
+         * @param id Document identifier.
+         * @param data Data to merge with the document.
+         */
+        async update(path: string, id: string, data: any): Promise<any> {
+                await this._waitConnection();
+                return this._db.collection(path).doc(id).update(data);
+        }
+
+        /**
+         * Delete a document from the specified collection.
+         *
+         * @param path Collection path.
+         * @param id Document identifier.
+         */
+        async delete(path: string, id: string): Promise<any> {
+                await this._waitConnection();
+                return this._db.collection(path).doc(id).delete();
+        }
+}

--- a/projects/wacom/src/lib/services/firestore.service.ts
+++ b/projects/wacom/src/lib/services/firestore.service.ts
@@ -1,6 +1,0 @@
-import { Injectable } from '@angular/core';
-
-@Injectable({
-	providedIn: 'root',
-})
-export abstract class FirestoreService<T> {}

--- a/projects/wacom/src/public-api.ts
+++ b/projects/wacom/src/public-api.ts
@@ -5,6 +5,7 @@ export * from './lib/interfaces/alert.interface';
 export * from './lib/interfaces/config.interface';
 export * from './lib/interfaces/crud.interface';
 export * from './lib/interfaces/modal.interface';
+export * from './lib/interfaces/firebase.interface';
 /*
  *	Guard
  */
@@ -41,6 +42,7 @@ export * from './lib/services/core.service';
 export * from './lib/services/crud.service';
 export * from './lib/services/dom.service';
 export * from './lib/services/file.service';
+export * from './lib/services/firebase.service';
 export * from './lib/services/http.service';
 export * from './lib/services/loader.service';
 export * from './lib/services/meta.service';


### PR DESCRIPTION
## Summary
- add FirebaseService for Firestore connection and CRUD helpers
- extend configuration interface with Firebase options
- document Firebase service usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e551700c48333a35c7d442720194d