### PR TITLE
feat(socket): handle disconnects and errors

### DIFF
--- a/projects/wacom/src/lib/services/socket.service.ts
+++ b/projects/wacom/src/lib/services/socket.service.ts
@@ -68,14 +68,43 @@ export class SocketService {
 				? this._config.io.default
 				: this._config.io;
 
-			this._io = ioFunc(this._url, this._opts);
+                        this._io = ioFunc(this._url, this._opts);
 
-			this._io.on('connect', () => {
-				this._connected = true;
-				this._core.complete('socket');
-			});
-		}
-	}
+                        this._io.on('connect', () => {
+                                this._connected = true;
+                                this._core.complete('socket');
+                        });
+
+                        this._io.on('disconnect', (reason: any) => {
+                                this._connected = false;
+                                if (this._core && typeof this._core.emit === 'function') {
+                                        this._core.emit('socket_disconnect', reason);
+                                } else {
+                                        console.warn('Socket disconnected', reason);
+                                }
+                        });
+
+                        this._io.on('error', (err: any) => {
+                                this._connected = false;
+                                if (this._core && typeof this._core.emit === 'function') {
+                                        this._core.emit('socket_error', err);
+                                } else {
+                                        console.warn('Socket error', err);
+                                }
+                        });
+                }
+        }
+
+        /**
+         * Disconnects the WebSocket connection and resets the connection state.
+         */
+        disconnect(): void {
+                if (this._io) {
+                        this._io.disconnect();
+                }
+
+                this._connected = false;
+        }
 
 	/**
 	 * Subscribes to a WebSocket event.


### PR DESCRIPTION
## Summary
- add `disconnect()` method to SocketService
- handle socket disconnect and error events to reset state and report issues via `CoreService`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e540743948333b4e72f85fc330c52