### PR TITLE
refactor: make store get callback optional

### DIFF
--- a/projects/wacom/src/lib/services/http.service.ts
+++ b/projects/wacom/src/lib/services/http.service.ts
@@ -51,11 +51,9 @@ export class HttpService {
 		}
 
 		// Retrieve and set the base URL and headers from the store
-		this.store.get('http_url', (url) => {
-			this.url = url || this._http.url || '';
-
-			return url;
-		});
+                this.store.get('http_url', (url) => {
+                        this.url = url || this._http.url || '';
+                });
 
 		this.store.getJson('http_headers').then((headers) => {
 			headers ||= {};

--- a/projects/wacom/src/lib/services/store.service.ts
+++ b/projects/wacom/src/lib/services/store.service.ts
@@ -66,33 +66,39 @@ export class StoreService {
 	 * @param key - The storage key.
 	 * @returns A promise that resolves to the retrieved value or `null` if the key is missing.
 	 */
-	async get(
-		key: string,
-		callback: (value: string | null) => string | null = () => {
-			return null;
-		},
-		errCallback: (err: unknown) => void = () => {}
-	): Promise<string | null> {
-		key = this._applyPrefix(key);
+        async get(
+                key: string,
+                callback?: (value: string | null) => void,
+                errCallback: (err: unknown) => void = () => {}
+        ): Promise<string | null> {
+                key = this._applyPrefix(key);
 
-		try {
-			if (this._config.get) {
-				return await this._config.get(key, callback, errCallback);
-			} else {
-				const value = localStorage.getItem(key);
+                try {
+                        if (this._config.get) {
+                                const value = await this._config.get(
+                                        key,
+                                        (val: string) => {
+                                                callback?.(val ?? null);
+                                        },
+                                        errCallback
+                                );
 
-				callback(value ?? null);
+                                return value ?? null;
+                        } else {
+                                const value = localStorage.getItem(key);
 
-				return value ?? null;
-			}
-		} catch (err) {
-			console.error(err);
+                                callback?.(value ?? null);
 
-			errCallback(err);
+                                return value ?? null;
+                        }
+                } catch (err) {
+                        console.error(err);
 
-			return null;
-		}
-	}
+                        errCallback(err);
+
+                        return null;
+                }
+        }
 
 	/**
 	 * Sets a JSON value in storage asynchronously.


### PR DESCRIPTION
## Summary
- update `StoreService.get` to accept an optional void callback
- ignore callback return value and wrap config callbacks
- adjust `HttpService` usage accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ecf484d6483339bc9d35519787760