### PR TITLE
feat: add generics for store json helpers

### DIFF
--- a/projects/wacom/src/lib/services/crud.service.ts
+++ b/projects/wacom/src/lib/services/crud.service.ts
@@ -103,7 +103,9 @@ export abstract class CrudService<
 	}
 
 	async restoreDocs() {
-		const docs = await this.__store.getJson('docs_' + this._config.name);
+                const docs = await this.__store.getJson<Document[]>(
+                        'docs_' + this._config.name
+                );
 
 		if (Array.isArray(docs)) {
 			this._docs.push(...docs);
@@ -116,7 +118,10 @@ export abstract class CrudService<
 	 * Saves the current set of documents to local storage.
 	 */
 	setDocs(): void {
-		this.__store.setJson('docs_' + this._config.name, this._docs);
+                this.__store.setJson<Document[]>(
+                        'docs_' + this._config.name,
+                        this._docs
+                );
 	}
 
 	/**

--- a/projects/wacom/src/lib/services/http.service.ts
+++ b/projects/wacom/src/lib/services/http.service.ts
@@ -57,7 +57,9 @@ export class HttpService {
 			return url;
 		});
 
-		this.store.getJson('http_headers').then((headers) => {
+                this.store
+                        .getJson<Record<string, string>>('http_headers')
+                        .then((headers) => {
 			headers ||= {};
 
 			for (const header in headers) {
@@ -83,13 +85,16 @@ export class HttpService {
 	}
 
 	// Set a new HTTP header and update the stored headers
-	set(key: any, value: any) {
-		this._headers[key] = value;
+        set(key: any, value: any) {
+                this._headers[key] = value;
 
-		this.store.setJson('http_headers', this._headers);
+                this.store.setJson<Record<string, string>>(
+                        'http_headers',
+                        this._headers
+                );
 
-		this._http_headers = new HttpHeaders(this._headers);
-	}
+                this._http_headers = new HttpHeaders(this._headers);
+        }
 
 	// Get the value of a specific HTTP header
 	header(key: any) {
@@ -102,8 +107,11 @@ export class HttpService {
 
 		this._http_headers = new HttpHeaders(this._headers);
 
-		this.store.setJson('http_headers', this._headers);
-	}
+                this.store.setJson<Record<string, string>>(
+                        'http_headers',
+                        this._headers
+                );
+        }
 
 	// Internal method to make HTTP requests based on the method type
 	private _httpMethod(

--- a/projects/wacom/src/lib/services/store.service.ts
+++ b/projects/wacom/src/lib/services/store.service.ts
@@ -101,9 +101,9 @@ export class StoreService {
 	 * @param value - The value to store.
 	 * @returns A promise that resolves to a boolean indicating success.
 	 */
-	async setJson(key: string, value: any): Promise<boolean> {
-		return await this.set(key, JSON.stringify(value));
-	}
+        async setJson<T>(key: string, value: T): Promise<boolean> {
+                return await this.set(key, JSON.stringify(value));
+        }
 
 	/**
 	 * Gets a JSON value from storage asynchronously.
@@ -111,15 +111,15 @@ export class StoreService {
 	 * @param key - The storage key.
 	 * @returns A promise that resolves to the retrieved value.
 	 */
-	async getJson<Document = any>(key: string): Promise<Document | null> {
-		const value = await this.get(key);
+        async getJson<T = any>(key: string): Promise<T | null> {
+                const value = await this.get(key);
 
 		if (value === null) {
 			return null;
 		}
 
 		try {
-			return JSON.parse(value);
+                        return JSON.parse(value);
 		} catch (err) {
 			console.error(err);
 


### PR DESCRIPTION
## Summary
- add type-safe generics to StoreService JSON helpers
- specify generic types at call sites for CRUD and HTTP services

## Testing
- `npm test` (fails: Missing script "test")
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ecf6e3e488333a713eaa131f67500