### PR TITLE
feat(store): expose error in clear

### DIFF
--- a/projects/wacom/src/lib/interfaces/store.interface.ts
+++ b/projects/wacom/src/lib/interfaces/store.interface.ts
@@ -16,5 +16,8 @@ export interface StoreConfig {
 		cb?: () => void,
 		errCb?: (err: unknown) => void
 	) => Promise<boolean>;
-	clear?: (cb?: () => void, errCb?: () => void) => Promise<boolean>;
+        clear?: (
+                cb?: () => void,
+                errCb?: (err: unknown) => void
+        ) => Promise<boolean>;
 }

--- a/projects/wacom/src/lib/services/store.service.ts
+++ b/projects/wacom/src/lib/services/store.service.ts
@@ -168,28 +168,28 @@ export class StoreService {
 	 * @param errCallback - The callback to execute on error.
 	 * @returns A promise that resolves to a boolean indicating success.
 	 */
-	async clear(
-		callback?: () => void,
-		errCallback?: () => void
-	): Promise<boolean> {
-		try {
-			if (this._config.clear) {
-				await this._config.clear();
-			} else {
-				localStorage.clear();
+        async clear(
+                callback?: () => void,
+                errCallback?: (err: unknown) => void
+        ): Promise<boolean> {
+                try {
+                        if (this._config.clear) {
+                                await this._config.clear();
+                        } else {
+                                localStorage.clear();
 			}
 
 			callback?.();
 
-			return true;
-		} catch (err) {
-			console.error(err);
+                        return true;
+                } catch (err) {
+                        console.error(err);
 
-			errCallback?.();
+                        errCallback?.(err);
 
-			return false;
-		}
-	}
+                        return false;
+                }
+        }
 
 	private _prefix = '';
 


### PR DESCRIPTION
## Summary
- allow StoreService.clear to pass error objects to callback
- type StoreConfig.clear to match other store hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ecf6467d883339c0a798cbb584f8e