### PR TITLE
refactor: add generic typing for dynamic component helpers

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -2401,13 +2401,13 @@ Appends a component to a specified element by ID.
 
 **Parameters**:
 
--   `component` (any): The component to append.
--   `options` (any): The options to project into the component.
--   `id` (string): The ID of the element to append the component to.
+-   `component` (`Type<T>`): The component to append.
+-   `options` (`Partial<T>`): The options to project into the component.
+-   `id` (`string`): The ID of the element to append the component to.
 
 **Returns**:
 
--   An object containing the native element and the component reference.
+-   An object containing the native element and the component reference (`ComponentRef<T>`).
 
 **Example**:
 
@@ -2417,18 +2417,18 @@ console.log(result.nativeElement); // Output: The native DOM element
 console.log(result.componentRef); // Output: The component reference
 ```
 
-#### `appendComponent(component: any, options: any = {}, element: HTMLElement = this.core.document.body): { nativeElement: HTMLElement, componentRef: ComponentRef<any> }`
+#### `appendComponent<T>(component: Type<T>, options: Partial<T> = {}, element: HTMLElement = this.core.document.body): { nativeElement: HTMLElement, componentRef: ComponentRef<T> }`
 
 Appends a component to a specified element or to the body.
 **Parameters**:
 
--   `component` (any): The component to append.
--   `options` (any): The options to project into the component.
--   `element` (HTMLElement): The element to append the component to. Defaults to body.
+-   `component` (`Type<T>`): The component to append.
+-   `options` (`Partial<T>`): The options to project into the component.
+-   `element` (`HTMLElement`): The element to append the component to. Defaults to body.
 
 **Returns**:
 
--   An object containing the native element and the component reference.
+-   An object containing the native element and the component reference (`ComponentRef<T>`).
 
 **Example**:
 
@@ -2438,17 +2438,17 @@ console.log(result.nativeElement); // Output: The native DOM element
 console.log(result.componentRef); // Output: The component reference
 ```
 
-#### `getComponentRef(component: any, options: any = {}): ComponentRef<any>`
+#### `getComponentRef<T>(component: Type<T>, options: Partial<T> = {}): ComponentRef<T>`
 
 Gets a reference to a dynamically created component.
 **Parameters**:
 
--   `component` (any): The component to create.
--   `options` (any): The options to project into the component.
+-   `component` (`Type<T>`): The component to create.
+-   `options` (`Partial<T>`): The options to project into the component.
 
 **Returns**:
 
--   The component reference.
+-   The component reference (`ComponentRef<T>`).
 
 **Example**:
 
@@ -2457,7 +2457,7 @@ const componentRef = domService.getComponentRef(MyComponent, { inputProp: 'value
 console.log(componentRef); // Output: The component reference
 ```
 
-#### `projectComponentInputs(component: ComponentRef<any>, options: any): ComponentRef<any>`
+#### `projectComponentInputs<T>(component: ComponentRef<T>, options: Partial<T>): ComponentRef<T>`
 
 Projects the inputs onto the component.
 **Parameters**:

--- a/projects/wacom/src/lib/services/alert.service.ts
+++ b/projects/wacom/src/lib/services/alert.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Inject, Injectable, Optional, ComponentRef } from '@angular/core';
 import { AlertComponent } from '../components/alert/alert.component';
 import { WrapperComponent } from '../components/alert/wrapper/wrapper.component';
 import { Alert, DEFAULT_Alert } from '../interfaces/alert.interface';
@@ -13,8 +13,11 @@ import { DomService } from './dom.service';
 	providedIn: 'root',
 })
 export class AlertService {
-	private alert: any;
-	private _container: any;
+        private alert: any;
+        private _container: {
+                nativeElement: HTMLElement;
+                componentRef: ComponentRef<WrapperComponent>;
+        };
 	constructor(
 		private dom: DomService,
 		@Inject(CONFIG_TOKEN) @Optional() private config: Config
@@ -29,8 +32,8 @@ export class AlertService {
 				this.alert[each] = DEFAULT_Alert[each];
 			}
 		}
-		this._container = this.dom.appendComponent(WrapperComponent);
-	}
+                this._container = this.dom.appendComponent(WrapperComponent)!;
+        }
 	private uniques: any = {};
 	private shortcuts: any = {
 		tl: 'topLeft',
@@ -55,7 +58,7 @@ export class AlertService {
 		center: 6,
 	};
 
-	show(opts: any | Alert) {
+        show(opts: any | Alert) {
 		if (typeof opts === 'string') {
 			opts = {
 				text: opts,
@@ -72,7 +75,10 @@ export class AlertService {
 		if (this.shortcuts[opts.position])
 			opts.position = this.shortcuts[opts.position];
 		if (!opts.position) opts.position = 'bottomRight';
-		var content: any;
+                let content: {
+                        nativeElement: HTMLElement;
+                        componentRef: ComponentRef<any>;
+                };
 		opts.close = () => {
 			if (content) content.componentRef.destroy();
 			opts.component.nativeElement.remove();
@@ -97,14 +103,14 @@ export class AlertService {
 		}
 
 		if (typeof opts.component === 'function') {
-			content = this.dom.appendComponent(
-				opts.component,
-				opts,
-				this._container.nativeElement.children[0].children[
-					this.positionNumber[opts.position] || 0
-				]
-				// component.nativeElement.children[0].children[0].children[0] as HTMLElement
-			);
+                        content = this.dom.appendComponent(
+                                opts.component,
+                                opts,
+                                this._container.nativeElement.children[0].children[
+                                        this.positionNumber[opts.position] || 0
+                                ] as HTMLElement
+                                // component.nativeElement.children[0].children[0].children[0] as HTMLElement
+                        )!;
 		}
 
 		if (opts.unique) {

--- a/projects/wacom/src/lib/services/dom.service.ts
+++ b/projects/wacom/src/lib/services/dom.service.ts
@@ -1,10 +1,11 @@
 import {
-	ApplicationRef,
-	ComponentRef,
-	EmbeddedViewRef,
-	EnvironmentInjector,
-	Injectable,
-	createComponent,
+        ApplicationRef,
+        ComponentRef,
+        EmbeddedViewRef,
+        EnvironmentInjector,
+        Injectable,
+        Type,
+        createComponent,
 } from '@angular/core';
 
 @Injectable({
@@ -26,21 +27,21 @@ export class DomService {
 	 * @param id - The ID of the element to append the component to.
 	 * @returns An object containing the native element and the component reference.
 	 */
-	appendById(
-		component: any,
-		options: any = {},
-		id: string
-	): { nativeElement: HTMLElement; componentRef: ComponentRef<any> } {
-		const componentRef = createComponent(component, {
-			environmentInjector: this.injector,
-		});
+        appendById<T>(
+                component: Type<T>,
+                options: Partial<T> = {},
+                id: string
+        ): { nativeElement: HTMLElement; componentRef: ComponentRef<T> } {
+                const componentRef = createComponent(component, {
+                        environmentInjector: this.injector,
+                });
 
 		this.projectComponentInputs(componentRef, options);
 
-		this.appRef.attachView(componentRef.hostView);
+                this.appRef.attachView(componentRef.hostView);
 
-		const domElem = (componentRef.hostView as EmbeddedViewRef<any>)
-			.rootNodes[0] as HTMLElement;
+                const domElem = (componentRef.hostView as EmbeddedViewRef<T>)
+                        .rootNodes[0] as HTMLElement;
 
 		const element = document.getElementById(id);
 
@@ -62,39 +63,39 @@ export class DomService {
 	 * @param element - The element to append the component to. Defaults to body.
 	 * @returns An object containing the native element and the component reference.
 	 */
-	appendComponent(
-		component: any,
-		options: any = {},
-		element: HTMLElement = document.body
-	): { nativeElement: HTMLElement; componentRef: ComponentRef<any> } | void {
-		if (options.providedIn) {
-			if (this.providedIn[options.providedIn]) {
-				return;
-			}
+        appendComponent<T>(
+                component: Type<T>,
+                options: Partial<T & { providedIn?: string }> = {},
+                element: HTMLElement = document.body
+        ): { nativeElement: HTMLElement; componentRef: ComponentRef<T> } | void {
+                if (options.providedIn) {
+                        if (this.providedIn[options.providedIn]) {
+                                return;
+                        }
 
-			this.providedIn[options.providedIn] = true;
-		}
+                        this.providedIn[options.providedIn] = true;
+                }
 
-		const componentRef = createComponent(component, {
-			environmentInjector: this.injector,
-		});
+                const componentRef = createComponent(component, {
+                        environmentInjector: this.injector,
+                });
 
-		this.projectComponentInputs(componentRef, options);
+                this.projectComponentInputs(componentRef, options);
 
-		this.appRef.attachView(componentRef.hostView);
+                this.appRef.attachView(componentRef.hostView);
 
-		const domElem = (componentRef.hostView as EmbeddedViewRef<any>)
-			.rootNodes[0] as HTMLElement;
+                const domElem = (componentRef.hostView as EmbeddedViewRef<T>)
+                        .rootNodes[0] as HTMLElement;
 
 		if (element && typeof element.appendChild === 'function') {
 			element.appendChild(domElem);
 		}
 
-		return {
-			nativeElement: domElem,
-			componentRef: componentRef,
-		};
-	}
+                return {
+                        nativeElement: domElem,
+                        componentRef: componentRef,
+                };
+        }
 
 	/**
 	 * Gets a reference to a dynamically created component.
@@ -103,17 +104,20 @@ export class DomService {
 	 * @param options - The options to project into the component.
 	 * @returns The component reference.
 	 */
-	getComponentRef(component: any, options: any = {}): ComponentRef<any> {
-		const componentRef = createComponent(component, {
-			environmentInjector: this.injector,
-		});
+        getComponentRef<T>(
+                component: Type<T>,
+                options: Partial<T> = {}
+        ): ComponentRef<T> {
+                const componentRef = createComponent(component, {
+                        environmentInjector: this.injector,
+                });
 
-		this.projectComponentInputs(componentRef, options);
+                this.projectComponentInputs(componentRef, options);
 
-		this.appRef.attachView(componentRef.hostView);
+                this.appRef.attachView(componentRef.hostView);
 
-		return componentRef;
-	}
+                return componentRef;
+        }
 
 	/**
 	 * Projects the inputs onto the component.
@@ -122,18 +126,18 @@ export class DomService {
 	 * @param options - The options to project into the component.
 	 * @returns The component reference with the projected inputs.
 	 */
-	private projectComponentInputs(
-		component: ComponentRef<any>,
-		options: any
-	): ComponentRef<any> {
-		if (options) {
-			const props = Object.getOwnPropertyNames(options);
+        private projectComponentInputs<T>(
+                component: ComponentRef<T>,
+                options: Partial<T>
+        ): ComponentRef<T> {
+                if (options) {
+                        const props = Object.getOwnPropertyNames(options);
 
-			for (const prop of props) {
-				component.instance[prop] = options[prop];
-			}
-		}
+                        for (const prop of props) {
+                                (component.instance as any)[prop] = (options as any)[prop];
+                        }
+                }
 
-		return component;
-	}
+                return component;
+        }
 }

--- a/projects/wacom/src/lib/services/loader.service.ts
+++ b/projects/wacom/src/lib/services/loader.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Inject, Injectable, Optional, ComponentRef } from '@angular/core';
 import { LoaderComponent } from '../components/loader/loader.component';
 import { CONFIG_TOKEN, Config } from '../interfaces/config.interface';
 import { DomService } from './dom.service';
@@ -7,30 +7,42 @@ import { DomService } from './dom.service';
 	providedIn: 'root',
 })
 export class LoaderService {
-	public loaders: any = [];
-	constructor(
-		private dom: DomService,
-		@Inject(CONFIG_TOKEN) @Optional() private config: Config
-	) {}
-	show(opts?: any) {
-		let component: any;
-		opts.close = () => {
-			if (component) component.componentRef.destroy();
-			component.nativeElement.remove();
-			if (typeof opts.onClose == 'function') opts.onClose();
-		};
-		if (opts.append) {
-			component = this.dom.appendComponent(
-				LoaderComponent,
-				opts,
-				opts.append
-			);
-		} else {
-			component = this.dom.appendComponent(LoaderComponent, opts);
-		}
-		this.loaders.push(component);
-		return component.nativeElement;
-	}
+        public loaders: Array<{
+                nativeElement: HTMLElement;
+                componentRef: ComponentRef<LoaderComponent>;
+        }> = [];
+        constructor(
+                private dom: DomService,
+                @Inject(CONFIG_TOKEN) @Optional() private config: Config
+        ) {}
+        show(
+                opts: Partial<LoaderComponent> & {
+                        append?: HTMLElement;
+                        onClose?: () => void;
+                        close?: () => void;
+                } = {}
+        ) {
+                let component!: {
+                        nativeElement: HTMLElement;
+                        componentRef: ComponentRef<LoaderComponent>;
+                };
+                opts.close = () => {
+                        if (component) component.componentRef.destroy();
+                        component.nativeElement.remove();
+                        if (typeof opts.onClose == 'function') opts.onClose();
+                };
+                if (opts.append) {
+                        component = this.dom.appendComponent(
+                                LoaderComponent,
+                                opts,
+                                opts.append
+                        )!;
+                } else {
+                        component = this.dom.appendComponent(LoaderComponent, opts)!;
+                }
+                this.loaders.push(component);
+                return component.nativeElement;
+        }
 	destroy() {
 		for (let i = this.loaders.length - 1; i >= 0; i--) {
 			this.loaders[i].componentRef.destroy();

--- a/projects/wacom/src/lib/services/modal.service.ts
+++ b/projects/wacom/src/lib/services/modal.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Inject, Injectable, Optional, ComponentRef } from '@angular/core';
 import { ModalComponent } from '../components/modal/modal.component';
 import { CONFIG_TOKEN, Config } from '../interfaces/config.interface';
 import { Modal } from '../interfaces/modal.interface';
@@ -46,9 +46,15 @@ export class ModalService {
 		}
 		opts.id = Math.floor(Math.random() * Date.now()) + Date.now();
 		this.opened[opts.id] = opts;
-		document.body.classList.add('modalOpened');
-		let component: any;
-		let content: any;
+                document.body.classList.add('modalOpened');
+                let component: {
+                        nativeElement: HTMLElement;
+                        componentRef: ComponentRef<ModalComponent>;
+                };
+                let content: {
+                        nativeElement: HTMLElement;
+                        componentRef: ComponentRef<any>;
+                };
 		opts.close = () => {
 			content.componentRef.destroy();
 			component.nativeElement.remove();
@@ -61,13 +67,13 @@ export class ModalService {
 		if (typeof opts.timeout == 'number' && opts.timeout > 0) {
 			setTimeout(opts.close, opts.timeout);
 		}
-		component = this.dom.appendComponent(ModalComponent, opts);
-		content = this.dom.appendComponent(
-			opts.component,
-			opts,
-			component.nativeElement.children[0].children[0]
-				.children[0] as HTMLElement
-		);
+                component = this.dom.appendComponent(ModalComponent, opts)!;
+                content = this.dom.appendComponent(
+                        opts.component,
+                        opts,
+                        component.nativeElement.children[0].children[0]
+                                .children[0] as HTMLElement
+                )!;
 		return component.nativeElement;
 	}
 	open(opts: Modal) {


### PR DESCRIPTION
## Summary
- use generics and Angular `Type<T>`/`Partial<T>` in DomService for dynamic component creation
- update services to use strongly typed results from `appendComponent`
- document generic signatures in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689edaf3a8ec833392ccc95d3c28c28d