### PR TITLE
feat: add cleanup handle for dynamic components

### DIFF
--- a/projects/wacom/src/lib/services/alert.service.ts
+++ b/projects/wacom/src/lib/services/alert.service.ts
@@ -29,8 +29,8 @@ export class AlertService {
 				this.alert[each] = DEFAULT_Alert[each];
 			}
 		}
-		this._container = this.dom.appendComponent(WrapperComponent);
-	}
+                this._container = this.dom.appendComponent(WrapperComponent);
+        }
 	private uniques: any = {};
 	private shortcuts: any = {
 		tl: 'topLeft',
@@ -72,13 +72,13 @@ export class AlertService {
 		if (this.shortcuts[opts.position])
 			opts.position = this.shortcuts[opts.position];
 		if (!opts.position) opts.position = 'bottomRight';
-		var content: any;
-		opts.close = () => {
-			if (content) content.componentRef.destroy();
-			opts.component.nativeElement.remove();
-			if (typeof (opts as Alert).onClose == 'function')
-				(opts as Alert).onClose();
-		};
+                var content: any;
+                opts.close = () => {
+                        content?.remove?.();
+                        (opts.component as any)?.remove?.();
+                        if (typeof (opts as Alert).onClose == 'function')
+                                (opts as Alert).onClose();
+                };
 		// let component = this.dom.appendById(AlertComponent, opts, opts.position);
 		let customElement = false;
 
@@ -154,10 +154,10 @@ export class AlertService {
 		this.show(opts);
 	}
 
-	destroy() {
-		[
-			'bottomRight',
-			'bottomLeft',
+        destroy() {
+                [
+                        'bottomRight',
+                        'bottomLeft',
 			'bottomCenter',
 			'topRight',
 			'topLeft',
@@ -167,6 +167,7 @@ export class AlertService {
 			const el = document.getElementById(id);
 
 			if (el) el.innerHTML = '';
-		});
-	}
+                });
+        }
+
 }

--- a/projects/wacom/src/lib/services/file.service.ts
+++ b/projects/wacom/src/lib/services/file.service.ts
@@ -27,14 +27,16 @@ interface FileOptions {
 	providedIn: 'root',
 })
 export class FileService {
-	private added: Record<string, FileOptions> = {};
-	private files: FileOptions[] = [];
+        private added: Record<string, FileOptions> = {};
+        private files: FileOptions[] = [];
+        private component: any;
 
-	constructor(private dom: DomService, private http: HttpService) {
-		this.dom.appendComponent(FilesComponent, {
-			fs: this,
-		});
-	}
+        constructor(private dom: DomService, private http: HttpService) {
+                this.component = this.dom.appendComponent(FilesComponent, {
+                        fs: this,
+                });
+        }
+
 
 	/**
 	 * Adds a file input configuration.

--- a/projects/wacom/src/lib/services/loader.service.ts
+++ b/projects/wacom/src/lib/services/loader.service.ts
@@ -11,30 +11,29 @@ export class LoaderService {
 	constructor(
 		private dom: DomService,
 		@Inject(CONFIG_TOKEN) @Optional() private config: Config
-	) {}
-	show(opts?: any) {
-		let component: any;
-		opts.close = () => {
-			if (component) component.componentRef.destroy();
-			component.nativeElement.remove();
-			if (typeof opts.onClose == 'function') opts.onClose();
-		};
-		if (opts.append) {
-			component = this.dom.appendComponent(
-				LoaderComponent,
+        ) {}
+        show(opts?: any) {
+                let component: any;
+                opts.close = () => {
+                        component?.remove();
+                        if (typeof opts.onClose == 'function') opts.onClose();
+                };
+                if (opts.append) {
+                        component = this.dom.appendComponent(
+                                LoaderComponent,
 				opts,
 				opts.append
 			);
 		} else {
 			component = this.dom.appendComponent(LoaderComponent, opts);
 		}
-		this.loaders.push(component);
-		return component.nativeElement;
-	}
-	destroy() {
-		for (let i = this.loaders.length - 1; i >= 0; i--) {
-			this.loaders[i].componentRef.destroy();
-			this.loaders.splice(i, 1);
-		}
-	}
+                this.loaders.push(component);
+                return component.nativeElement;
+        }
+        destroy() {
+                for (let i = this.loaders.length - 1; i >= 0; i--) {
+                        this.loaders[i].remove();
+                        this.loaders.splice(i, 1);
+                }
+        }
 }

--- a/projects/wacom/src/lib/services/modal.service.ts
+++ b/projects/wacom/src/lib/services/modal.service.ts
@@ -46,17 +46,17 @@ export class ModalService {
 		}
 		opts.id = Math.floor(Math.random() * Date.now()) + Date.now();
 		this.opened[opts.id] = opts;
-		document.body.classList.add('modalOpened');
-		let component: any;
-		let content: any;
-		opts.close = () => {
-			content.componentRef.destroy();
-			component.nativeElement.remove();
-			if (typeof opts.onClose == 'function') opts.onClose();
-			delete this.opened[opts.id];
-			if (!Object.keys(this.opened).length) {
-				document.body.classList.remove('modalOpened');
-			}
+                document.body.classList.add('modalOpened');
+                let component: any;
+                let content: any;
+                opts.close = () => {
+                        content?.remove();
+                        component?.remove();
+                        if (typeof opts.onClose == 'function') opts.onClose();
+                        delete this.opened[opts.id];
+                        if (!Object.keys(this.opened).length) {
+                                document.body.classList.remove('modalOpened');
+                        }
 		};
 		if (typeof opts.timeout == 'number' && opts.timeout > 0) {
 			setTimeout(opts.close, opts.timeout);


### PR DESCRIPTION
## Summary
- add `removeComponent` to DomService to detach, destroy, and clear `providedIn` entries
- return disposable handles from `appendComponent`/`appendById`
- update loader, modal, alert, and file services to dispose dynamic components
- remove unneeded `OnDestroy` hooks from alert and file services

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689edae6c65c8333b17ceab4f6674385