### PR TITLE
feat: add component cleanup handles

### DIFF
--- a/projects/wacom/README.md
+++ b/projects/wacom/README.md
@@ -2494,6 +2494,7 @@ export class AppComponent {
     const result = this.domService.appendById(MyComponent, { inputProp: 'value' }, 'elementId');
     console.log(result.nativeElement); // Output: The native DOM element
     console.log(result.componentRef); // Output: The component reference
+    result.remove(); // Cleanup when done
   }
 }
 ```

--- a/projects/wacom/src/lib/services/file.service.ts
+++ b/projects/wacom/src/lib/services/file.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FilesComponent } from '../components/files/files.component';
-import { DomService } from './dom.service';
+import { DomComponent, DomService } from './dom.service';
 import { HttpService } from './http.service';
 
 interface FileOptions {
@@ -27,14 +27,15 @@ interface FileOptions {
 	providedIn: 'root',
 })
 export class FileService {
-	private added: Record<string, FileOptions> = {};
-	private files: FileOptions[] = [];
+        private added: Record<string, FileOptions> = {};
+        private files: FileOptions[] = [];
+        private _component: DomComponent<FilesComponent>;
 
-	constructor(private dom: DomService, private http: HttpService) {
-		this.dom.appendComponent(FilesComponent, {
-			fs: this,
-		});
-	}
+        constructor(private dom: DomService, private http: HttpService) {
+                this._component = this.dom.appendComponent(FilesComponent, {
+                        fs: this,
+                })!;
+        }
 
 	/**
 	 * Adds a file input configuration.
@@ -279,7 +280,7 @@ export class FileService {
 	 * @param info - The file options.
 	 */
 	// private process(file: File, info: FileOptions): void {
-	process(file: File, info: any): void {
+        process(file: File, info: any): void {
 		if (!file.type.startsWith('image/')) {
 			info.cb?.(false, file);
 			if (info.multiple_cb) {
@@ -339,6 +340,10 @@ export class FileService {
 			};
 			img.src = loadEvent.target?.result as string;
 		};
-		reader.readAsDataURL(file);
-	}
+                reader.readAsDataURL(file);
+        }
+
+        destroy() {
+                this._component.remove();
+        }
 }

--- a/projects/wacom/src/lib/services/loader.service.ts
+++ b/projects/wacom/src/lib/services/loader.service.ts
@@ -1,16 +1,13 @@
-import { ComponentRef, Inject, Injectable, Optional } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { LoaderComponent } from '../components/loader/loader.component';
 import { CONFIG_TOKEN, Config } from '../interfaces/config.interface';
-import { DomService } from './dom.service';
+import { DomComponent, DomService } from './dom.service';
 
 @Injectable({
 	providedIn: 'root',
 })
 export class LoaderService {
-	public loaders: Array<{
-		nativeElement: HTMLElement;
-		componentRef: ComponentRef<LoaderComponent>;
-	}> = [];
+        public loaders: Array<DomComponent<LoaderComponent>> = [];
 	constructor(
 		private dom: DomService,
 		@Inject(CONFIG_TOKEN) @Optional() private config: Config
@@ -22,31 +19,27 @@ export class LoaderService {
 			close?: () => void;
 		} = {}
 	) {
-		let component!: {
-			nativeElement: HTMLElement;
-			componentRef: ComponentRef<LoaderComponent>;
-		};
-		opts.close = () => {
-			if (component) component.componentRef.destroy();
-			component.nativeElement.remove();
-			if (typeof opts.onClose == 'function') opts.onClose();
-		};
-		if (opts.append) {
-			component = this.dom.appendComponent(
-				LoaderComponent,
-				opts,
-				opts.append
-			)!;
-		} else {
-			component = this.dom.appendComponent(LoaderComponent, opts)!;
-		}
-		this.loaders.push(component);
-		return component.nativeElement;
-	}
-	destroy() {
-		for (let i = this.loaders.length - 1; i >= 0; i--) {
-			this.loaders[i].componentRef.destroy();
-			this.loaders.splice(i, 1);
-		}
-	}
+                let component!: DomComponent<LoaderComponent>;
+                opts.close = () => {
+                        component?.remove();
+                        if (typeof opts.onClose == 'function') opts.onClose();
+                };
+                if (opts.append) {
+                        component = this.dom.appendComponent(
+                                LoaderComponent,
+                                opts,
+                                opts.append
+                        )!;
+                } else {
+                        component = this.dom.appendComponent(LoaderComponent, opts)!;
+                }
+                this.loaders.push(component);
+                return component.nativeElement;
+        }
+        destroy() {
+                for (let i = this.loaders.length - 1; i >= 0; i--) {
+                        this.loaders[i].remove();
+                        this.loaders.splice(i, 1);
+                }
+        }
 }

--- a/projects/wacom/src/lib/services/modal.service.ts
+++ b/projects/wacom/src/lib/services/modal.service.ts
@@ -1,8 +1,8 @@
-import { ComponentRef, Inject, Injectable, Optional } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { ModalComponent } from '../components/modal/modal.component';
 import { CONFIG_TOKEN, Config } from '../interfaces/config.interface';
 import { Modal } from '../interfaces/modal.interface';
-import { DomService } from './dom.service';
+import { DomComponent, DomService } from './dom.service';
 @Injectable({
 	providedIn: 'root',
 })
@@ -47,33 +47,27 @@ export class ModalService {
 		opts.id = Math.floor(Math.random() * Date.now()) + Date.now();
 		this.opened[opts.id] = opts;
 		document.body.classList.add('modalOpened');
-		let component: {
-			nativeElement: HTMLElement;
-			componentRef: ComponentRef<ModalComponent>;
-		};
-		let content: {
-			nativeElement: HTMLElement;
-			componentRef: ComponentRef<any>;
-		};
-		opts.close = () => {
-			content.componentRef.destroy();
-			component.nativeElement.remove();
-			if (typeof opts.onClose == 'function') opts.onClose();
-			delete this.opened[opts.id];
-			if (!Object.keys(this.opened).length) {
-				document.body.classList.remove('modalOpened');
-			}
-		};
+                let component!: DomComponent<ModalComponent>;
+                let content!: DomComponent<any>;
+                opts.close = () => {
+                        content?.remove();
+                        component.remove();
+                        if (typeof opts.onClose == 'function') opts.onClose();
+                        delete this.opened[opts.id];
+                        if (!Object.keys(this.opened).length) {
+                                document.body.classList.remove('modalOpened');
+                        }
+                };
 		if (typeof opts.timeout == 'number' && opts.timeout > 0) {
 			setTimeout(opts.close, opts.timeout);
 		}
-		component = this.dom.appendComponent(ModalComponent, opts)!;
-		content = this.dom.appendComponent(
-			opts.component,
-			opts,
-			component.nativeElement.children[0].children[0]
-				.children[0] as HTMLElement
-		)!;
+                component = this.dom.appendComponent(ModalComponent, opts)!;
+                content = this.dom.appendComponent(
+                        opts.component,
+                        opts,
+                        component.nativeElement.children[0].children[0]
+                                .children[0] as HTMLElement
+                )!;
 		return component.nativeElement;
 	}
 	open(opts: Modal) {


### PR DESCRIPTION
## Summary
- add DomComponent interface with remove handle and expose removeComponent
- return cleanup handle from appendById and appendComponent
- use cleanup in alert, loader, modal, and file services

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ee4fe001483339bc808e816d80701