### PR TITLE
docs: document alert components and service

### DIFF
--- a/projects/wacom/src/lib/components/alert/alert/alert.component.ts
+++ b/projects/wacom/src/lib/components/alert/alert/alert.component.ts
@@ -12,32 +12,53 @@ import {
 	styleUrls: ['./alert.component.scss'],
 	imports: [CommonModule],
 })
+/**
+ * Displays an individual alert message with optional icon, actions and
+ * auto‑dismiss behaviour. All inputs are configured by the service when the
+ * component is created dynamically.
+ */
 export class AlertComponent implements OnInit {
-	@ViewChild('alertRef', { static: false }) alertRef: any;
+        /** Reference to the DOM element hosting the alert. */
+        @ViewChild('alertRef', { static: false }) alertRef: any;
 
-	close: () => void = () => {};
+        /** Callback invoked to remove the alert from the DOM. */
+        close: () => void = () => {};
 
-	text: string = '';
+        /** Text content displayed inside the alert. */
+        text: string = '';
 
-	class: string = '';
+        /** Additional CSS classes applied to the alert container. */
+        class: string = '';
 
-	type: AlertType = 'info';
+        /** Type of alert which determines styling and icon. */
+        type: AlertType = 'info';
 
-	position: AlertPosition = 'bottomRight';
+        /** Position on the screen where the alert appears. */
+        position: AlertPosition = 'bottomRight';
 
-	progress: boolean = true;
+        /** Whether a progress bar indicating remaining time is shown. */
+        progress: boolean = true;
 
-	icon: string = '';
+        /** Icon name displayed alongside the message. */
+        icon: string = '';
 
-	timeout: number = 5000;
+        /** Time in milliseconds before the alert auto closes. */
+        timeout: number = 5000;
 
-	closable: boolean = true;
+        /** Determines if a manual close button is visible. */
+        closable: boolean = true;
 
-	delete_animation = false;
+        /** Flag used to trigger the deletion animation. */
+        delete_animation = false;
 
-	buttons: AlertButton[] = [];
+        /** Optional action buttons rendered within the alert. */
+        buttons: AlertButton[] = [];
 
-	ngOnInit(): void {
+        /**
+         * Starts the auto‑dismiss timer and pauses it while the alert is
+         * hovered, resuming when the mouse leaves.
+         */
+        ngOnInit(): void {
 		if (this.timeout) {
 			let remaining = JSON.parse(JSON.stringify(this.timeout));
 
@@ -73,13 +94,17 @@ export class AlertComponent implements OnInit {
 		}
 	}
 
-	remove() {
-		this.delete_animation = true;
+        /**
+         * Triggers the closing animation and invokes the provided close
+         * callback once finished.
+         */
+        remove() {
+                this.delete_animation = true;
 
-		setTimeout(() => {
-			this.close();
+                setTimeout(() => {
+                        this.close();
 
-			this.delete_animation = false;
-		}, 350);
-	}
+                        this.delete_animation = false;
+                }, 350);
+        }
 }

--- a/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.ts
+++ b/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.ts
@@ -1,9 +1,13 @@
 import { Component } from '@angular/core';
 
 @Component({
-	selector: 'lib-wrapper',
-	templateUrl: './wrapper.component.html',
-	styleUrls: ['./wrapper.component.scss'],
-	imports: [],
+        selector: 'lib-wrapper',
+        templateUrl: './wrapper.component.html',
+        styleUrls: ['./wrapper.component.scss'],
+        imports: [],
 })
+/**
+ * Container component that provides placeholder elements for alert instances
+ * rendered in different screen positions.
+ */
 export class WrapperComponent {}

--- a/projects/wacom/src/lib/interfaces/alert.interface.ts
+++ b/projects/wacom/src/lib/interfaces/alert.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * Possible alert variants that control styling and default icons.
+ */
 export const ALERT_TYPES = ['info', 'error', 'success', 'warning', 'question'];
 export type AlertType = (typeof ALERT_TYPES)[number];
 
@@ -12,22 +15,40 @@ export const ALERT_POSITIONS = [
 ];
 export type AlertPosition = (typeof ALERT_POSITIONS)[number];
 
+/**
+ * Configuration for a button rendered inside an alert.
+ */
 export interface AlertButton {
-	text: string;
-	callback?: () => void;
+        /** Text displayed on the button. */
+        text: string;
+        /** Optional click handler invoked when the button is pressed. */
+        callback?: () => void;
 }
 
+/**
+ * Base options that can be supplied when showing an alert.
+ */
 export interface AlertConfig {
-	text?: string;
-	type?: AlertType;
-	position?: AlertPosition;
-	icon?: string;
-	class?: string;
-	unique?: string;
-	progress?: boolean;
-	timeout?: number;
-	close?: () => void;
-	buttons?: AlertButton[];
+        /** Message text displayed to the user. */
+        text?: string;
+        /** One of {@link ALERT_TYPES} determining alert style. */
+        type?: AlertType;
+        /** Location on screen where the alert should appear. */
+        position?: AlertPosition;
+        /** Optional icon name to show with the message. */
+        icon?: string;
+        /** Custom CSS class applied to the alert container. */
+        class?: string;
+        /** Identifier used to ensure only one alert with this key exists. */
+        unique?: string;
+        /** Whether to show a progress bar. */
+        progress?: boolean;
+        /** Milliseconds before auto dismissal. */
+        timeout?: number;
+        /** Callback executed when the alert is closed. */
+        close?: () => void;
+        /** Optional action buttons displayed within the alert. */
+        buttons?: AlertButton[];
 }
 
 export interface Alert extends AlertConfig {
@@ -37,13 +58,16 @@ export interface Alert extends AlertConfig {
 	[x: string]: any;
 }
 
+/**
+ * Default values applied when an alert is shown without specific options.
+ */
 export const DEFAULT_ALERT_CONFIG: Alert = {
-	text: '',
-	type: 'info',
-	class: '',
-	progress: true,
-	position: 'bottomRight',
-	timeout: 3000,
-	closable: true,
-	buttons: [],
+        text: '',
+        type: 'info',
+        class: '',
+        progress: true,
+        position: 'bottomRight',
+        timeout: 3000,
+        closable: true,
+        buttons: [],
 };

--- a/projects/wacom/src/lib/services/alert.service.ts
+++ b/projects/wacom/src/lib/services/alert.service.ts
@@ -2,32 +2,47 @@ import { Inject, Injectable, Optional } from '@angular/core';
 import { AlertComponent } from '../components/alert/alert/alert.component';
 import { WrapperComponent } from '../components/alert/wrapper/wrapper.component';
 import {
-	Alert,
-	ALERT_POSITIONS,
-	AlertConfig,
-	DEFAULT_ALERT_CONFIG,
+        Alert,
+        ALERT_POSITIONS,
+        AlertConfig,
+        DEFAULT_ALERT_CONFIG,
 } from '../interfaces/alert.interface';
 import { Config, CONFIG_TOKEN } from '../interfaces/config.interface';
 import { DomComponent } from '../interfaces/dom.interface';
 import { DomService } from './dom.service';
 
 @Injectable({
-	providedIn: 'root',
+        providedIn: 'root',
 })
 export class AlertService {
-	constructor(
-		@Inject(CONFIG_TOKEN) @Optional() private config: Config,
-		private _dom: DomService
-	) {
-		this._config = {
-			...DEFAULT_ALERT_CONFIG,
-			...(this.config.alert || {}),
-		};
+        /**
+         * Creates a new alert service.
+         *
+         * @param config Optional global configuration provided via the
+         * `CONFIG_TOKEN` injection token.
+         * @param _dom Service responsible for DOM manipulation and dynamic
+         * component creation.
+         */
+        constructor(
+                @Inject(CONFIG_TOKEN) @Optional() private config: Config,
+                private _dom: DomService
+        ) {
+                this._config = {
+                        ...DEFAULT_ALERT_CONFIG,
+                        ...(this.config.alert || {}),
+                };
 
 		this._container = this._dom.appendComponent(WrapperComponent)!;
 	}
 
-	show(opts: Alert | string) {
+        /**
+         * Displays an alert. Accepts either an options object or a simple string
+         * which will be used as the alert text.
+         *
+         * @returns Reference to the created alert or embedded component
+         *          element.
+         */
+        show(opts: Alert | string) {
 		if (typeof opts === 'string') {
 			opts = {
 				...this._config,
@@ -90,63 +105,88 @@ export class AlertService {
 		return main.nativeElement;
 	}
 
-	open(opts: Alert) {
-		this.show(opts);
-	}
+        /**
+         * Convenience alias for `show`.
+         */
+        open(opts: Alert) {
+                this.show(opts);
+        }
 
-	info(opts: Alert) {
-		opts.type = 'info';
+        /**
+         * Displays an informational alert.
+         */
+        info(opts: Alert) {
+                opts.type = 'info';
 
-		this.show(opts);
-	}
+                this.show(opts);
+        }
 
-	success(opts: Alert) {
-		opts.type = 'success';
+        /**
+         * Displays a success alert.
+         */
+        success(opts: Alert) {
+                opts.type = 'success';
 
-		this.show(opts);
-	}
+                this.show(opts);
+        }
 
-	warning(opts: Alert) {
-		opts.type = 'warning';
+        /**
+         * Displays a warning alert.
+         */
+        warning(opts: Alert) {
+                opts.type = 'warning';
 
-		this.show(opts);
-	}
+                this.show(opts);
+        }
 
-	error(opts: Alert) {
-		opts.type = 'error';
+        /**
+         * Displays an error alert.
+         */
+        error(opts: Alert) {
+                opts.type = 'error';
 
-		this.show(opts);
-	}
+                this.show(opts);
+        }
 
-	question(opts: Alert) {
-		opts.type = 'question';
+        /**
+         * Displays a question alert.
+         */
+        question(opts: Alert) {
+                opts.type = 'question';
 
-		this.show(opts);
-	}
+                this.show(opts);
+        }
 
-	destroy() {
-		for (const id of ALERT_POSITIONS) {
-			const el = document.getElementById(id);
+        /**
+         * Removes all alert elements from the document.
+         */
+        destroy() {
+                for (const id of ALERT_POSITIONS) {
+                        const el = document.getElementById(id);
 
-			if (el) el.innerHTML = '';
-		}
-	}
+                        if (el) el.innerHTML = '';
+                }
+        }
 
-	private _config: AlertConfig;
+        /** Merged configuration applied to new alerts. */
+        private _config: AlertConfig;
 
-	private _container: DomComponent<WrapperComponent>;
+        /** Wrapper component that contains all alert placeholders. */
+        private _container: DomComponent<WrapperComponent>;
 
-	private _uniques: Record<string, DomComponent<any>> = {};
+        /** References to alerts that must remain unique by identifier. */
+        private _uniques: Record<string, DomComponent<any>> = {};
 
-	private _positionNumber: any = {
-		topLeft: 3,
-		topCenter: 4,
-		topRight: 2,
-		right: '',
-		bottomRight: 0,
-		bottomCenter: 5,
-		bottomLeft: 1,
-		left: '',
-		center: 6,
-	};
+        /** Mapping of alert positions to wrapper child indexes. */
+        private _positionNumber: any = {
+                topLeft: 3,
+                topCenter: 4,
+                topRight: 2,
+                right: '',
+                bottomRight: 0,
+                bottomCenter: 5,
+                bottomLeft: 1,
+                left: '',
+                center: 6,
+        };
 }


### PR DESCRIPTION
## Summary
- document alert component inputs, outputs, and methods
- add wrapper component description
- expand alert service and interface documentation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a19ae60cb08333a337d6316705c3fb