### PR TITLE
fix: expand center alerts to full width on mobile

### DIFF
--- a/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.scss
+++ b/projects/wacom/src/lib/components/alert/wrapper/wrapper.component.scss
@@ -79,10 +79,15 @@
         .waw-alert-wrapper-left,
         .waw-alert-wrapper-right,
         .waw-alert-wrapper-bottomLeft,
-        .waw-alert-wrapper-bottomRight {
+        .waw-alert-wrapper-bottomRight,
+        .waw-alert-wrapper-center {
                 left: 0;
                 right: 0;
                 text-align: center;
+        }
+
+        .waw-alert-wrapper-center {
+                align-items: stretch;
         }
 
         .waw-alert-wrapper-left,


### PR DESCRIPTION
## Summary
- allow center-positioned alerts to stretch full width on small screens

## Testing
- `npm test` (fails: Missing script: "test")
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a39ce8c720833398f61d855870d8c2