### PR TITLE
refactor loader styles into scss

### DIFF
--- a/projects/wacom/src/lib/components/loader/loader.component.html
+++ b/projects/wacom/src/lib/components/loader/loader.component.html
@@ -1,18 +1,6 @@
 <div
         class="waw-loader"
         [ngClass]="class"
-        style="
-                position: fixed;
-                width: 100%;
-                height: 100%;
-                left: 0;
-                top: 0;
-                background-color: #334d6e;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                z-index: 999999;
-        "
 >
         @if (progress) {
         <div class="waw-loader__progress">
@@ -27,7 +15,7 @@
         <span class="close" (click)="close()">&times;</span>
         }
         @if(text){
-        <span style="font-size: 30px; color: white">
+        <span class="waw-loader__text">
                 {{ text }}
         </span>
         }

--- a/projects/wacom/src/lib/components/loader/loader.component.scss
+++ b/projects/wacom/src/lib/components/loader/loader.component.scss
@@ -1,10 +1,24 @@
+/* The Loader Container */
+.waw-loader {
+        position: fixed;
+        width: 100%;
+        height: 100%;
+        left: 0;
+        top: 0;
+        background-color: #334d6e;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 999999;
+}
+
 /* The Close Button */
 .close {
-	color: #aaa;
-	position: absolute;
-	right: 20px;
-	top: 20px;
-	font-size: 32px;
+        color: #aaa;
+        position: absolute;
+        right: 20px;
+        top: 20px;
+        font-size: 32px;
 	line-height: 1;
 }
 
@@ -13,6 +27,12 @@
         color: black;
         text-decoration: none;
         cursor: pointer;
+}
+
+// Text displayed in the loader
+.waw-loader__text {
+        font-size: 30px;
+        color: white;
 }
 
 .waw-loader__progress {


### PR DESCRIPTION
## Summary
- remove inline styles from loader component template
- style loader container and text via SCSS

## Testing
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a39d37af6c8333bf8037b2a58fde9c