### PR TITLE
feat: style alert progress bar

### DIFF
--- a/projects/wacom/src/lib/components/alert/alert/alert.component.html
+++ b/projects/wacom/src/lib/components/alert/alert/alert.component.html
@@ -21,9 +21,8 @@
 		@if(progress) {
 		<div class="waw-alert__progress">
 			<span
-				[ngStyle]="{
-					'animation-duration': (timeout + 350) / 1000 + 's'
-				}"
+				[ngClass]="'_' + { info: 'blue', error: 'red', success: 'green', warning: 'orange', question: 'yellow' }[type]"
+				[ngStyle]="{ 'animation-duration': (timeout + 350) / 1000 + 's' }"
 			></span>
 		</div>
 		}

--- a/projects/wacom/src/lib/components/alert/alert/alert.component.scss
+++ b/projects/wacom/src/lib/components/alert/alert/alert.component.scss
@@ -206,8 +206,8 @@
 		}
 
 		&._blue {
-			background-color: rgba(255, 207, 165, 1);
-		}
+                        background-color: rgba(157, 222, 255, 1);
+                }
 
 		&._white {
 			background-color: white;


### PR DESCRIPTION
## Summary
- color progress indicator to match alert type
- fix incorrect blue progress color

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a772a96a008333afff2202ee13fe38