### PR TITLE
feat(loader): support progress percentage display

### DIFF
--- a/projects/wacom/src/lib/components/loader/loader.component.html
+++ b/projects/wacom/src/lib/components/loader/loader.component.html
@@ -1,17 +1,24 @@
 <div class="waw-loader" [ngClass]="class">
-	@if (progress) {
-	<div class="waw-loader__progress">
-		<span
-			[ngStyle]="{
-				'animation-duration': (timeout + 350) / 1000 + 's'
-			}"
-		></span>
-	</div>
-	} @if(closable){
-	<span class="close" (click)="close()">&times;</span>
-	} @if(text){
-	<span class="waw-loader__text">
-		{{ text }}
-	</span>
-	}
+        @if (progressPercentage) {
+        <div class="waw-loader__progress">
+                <span
+                        [style.width.%]="progressPercentage()"
+                        style="animation: none"
+                ></span>
+        </div>
+        } @else if (progress) {
+        <div class="waw-loader__progress">
+                <span
+                        [ngStyle]="{
+                                'animation-duration': (timeout + 350) / 1000 + 's'
+                        }"
+                ></span>
+        </div>
+        } @if(closable){
+        <span class="close" (click)="close()">&times;</span>
+        } @if(text){
+        <span class="waw-loader__text">
+                {{ text }}
+        </span>
+        }
 </div>

--- a/projects/wacom/src/lib/components/loader/loader.component.scss
+++ b/projects/wacom/src/lib/components/loader/loader.component.scss
@@ -36,19 +36,20 @@
 }
 
 .waw-loader__progress {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	width: 100%;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
 
-	span {
-		display: block;
-		width: 100%;
-		height: 2px;
-		background-color: #a5a5a5ed;
-		animation-name: waw-loader-progress;
-		animation-duration: 10s;
-	}
+        span {
+                display: block;
+                width: 100%;
+                height: 2px;
+                background-color: #a5a5a5ed;
+                animation-name: waw-loader-progress;
+                animation-duration: 10s;
+                transition: width 0.2s ease;
+        }
 }
 
 @keyframes waw-loader-progress {

--- a/projects/wacom/src/lib/components/loader/loader.component.ts
+++ b/projects/wacom/src/lib/components/loader/loader.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Signal } from '@angular/core';
 
 @Component({
 	templateUrl: './loader.component.html',
@@ -13,7 +13,9 @@ export class LoaderComponent implements OnInit {
 
 	class!: string;
 
-	progress!: boolean;
+        progress!: boolean;
+
+        progressPercentage?: Signal<number>;
 
 	timeout!: number;
 


### PR DESCRIPTION
## Summary
- support determinate loader with `progressPercentage` signal
- style loader progress bar for smooth width updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7755059c88333a4eee7fe58cf1bb2