### PR TITLE
feat(loader): display progress percentage

### DIFF
--- a/projects/wacom/src/lib/components/loader/loader.component.html
+++ b/projects/wacom/src/lib/components/loader/loader.component.html
@@ -6,6 +6,9 @@
                         style="animation: none"
                 ></span>
         </div>
+        <span class="waw-loader__progress-text">
+                {{ progressPercentage() }}%
+        </span>
         } @else if (progress) {
         <div class="waw-loader__progress">
                 <span

--- a/projects/wacom/src/lib/components/loader/loader.component.scss
+++ b/projects/wacom/src/lib/components/loader/loader.component.scss
@@ -31,8 +31,13 @@
 
 // Text displayed in the loader
 .waw-loader__text {
-	font-size: 30px;
-	color: white;
+        font-size: 30px;
+        color: white;
+}
+
+.waw-loader__progress-text {
+        font-size: 30px;
+        color: white;
 }
 
 .waw-loader__progress {


### PR DESCRIPTION
## Summary
- show progress bar percentage when a `progressPercentage` signal is provided
- style loader to display percentage text

## Testing
- `npx ng build wacom 2>&1 | tr '\r' '\n' | tail -n 20`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a776748b248333885715b75a6f218b